### PR TITLE
 Force all documents (terms and license) in UTF-8 

### DIFF
--- a/src/components/Document.js
+++ b/src/components/Document.js
@@ -1,0 +1,21 @@
+/**
+ * @author Samy Nastuzzi <samy@nastuzzi.fr>
+ *
+ * @copyright Copyright (c) 2019, SiMDE-UTC
+ * @license GPL-3.0
+ */
+
+import React from 'react';
+import { WebView } from 'react-native';
+
+export default function Document({ document, lang }) {
+	return (
+		<WebView
+			style={{ backgroundColor: 'transparent' }}
+			source={{
+				html: `<!DOCTYPE html><html lang="${lang ||
+					'en'}"><head><meta charset="utf-8"/></head><body><p style='font-family: sans-serif; text-align: justify; white-space: pre-wrap;'>${document}</p></body></html>`,
+			}}
+		/>
+	);
+}

--- a/src/screens/Settings/LicenseScreen.js
+++ b/src/screens/Settings/LicenseScreen.js
@@ -6,7 +6,7 @@
  */
 
 import React from 'react';
-import { WebView } from 'react-native';
+import Document from '../../components/Document';
 import { _, License as t } from '../../utils/i18n';
 import colors from '../../styles/colors';
 
@@ -247,13 +247,6 @@ export default class LicenseScreen extends React.Component {
 	});
 
 	render() {
-		return (
-			<WebView
-				style={{ backgroundColor: 'transparent' }}
-				source={{
-					html: `<p style='font-family: sans-serif; text-align: justify; white-space: pre-wrap;'>${LICENSE}</p>`,
-				}}
-			/>
-		);
+		return <Document lang="en" document={LICENSE} />;
 	}
 }

--- a/src/screens/Settings/TermsScreen.js
+++ b/src/screens/Settings/TermsScreen.js
@@ -6,9 +6,9 @@
  */
 
 import React from 'react';
-import { WebView } from 'react-native';
 import { connect } from 'react-redux';
 import ValidationScreen from '../../components/ValidationScreen';
+import Document from '../../components/Document';
 import { beautifyDateTime } from '../../utils';
 import { _, Terms as t } from '../../utils/i18n';
 import { Config } from '../../redux/actions';
@@ -59,12 +59,7 @@ class TermsScreen extends React.Component {
 				disabled={validated}
 				onPress={() => this.validate()}
 			>
-				<WebView
-					style={{ backgroundColor: 'transparent' }}
-					source={{
-						html: `<p style='font-family: sans-serif; text-align: justify; white-space: pre-wrap;'>${TERMS.fr}</p>`,
-					}}
-				/>
+				<Document lang="fr" document={TERMS.fr} />
 			</ValidationScreen>
 		);
 	}


### PR DESCRIPTION
Was like that on some random Webviews

![68930815_744210206022194_7558587810358231040_n](https://user-images.githubusercontent.com/24639904/63365723-7650a800-c378-11e9-9be9-640f56004805.png)
